### PR TITLE
Set mongoose as a peerDependency and a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "version": "1.0.0",
   "description": "Mongoose Query Pagination",
   "main": "./lib/pagination.js",
-  "dependencies":{
-    "mongoose":">=2.7.0"
+  "peerDependencies": {
+    "mongoose": ">=2.7.0"
   },
   "devDependencies":{
+    "mongoose": ">=2.7.0",
     "chai": "~1.3.0",
     "coffee-script": "~1.3.3",
     "mocha": "~1.6.0"


### PR DESCRIPTION
This closes issue #1 and prevents those sort of bugs from happening.
Maybe the right thing would be to also specify a npm version (as this has to be supported by the installed npm's version).
